### PR TITLE
Add domain name variables to cluster-vars ConfigMap

### DIFF
--- a/clusters/home/flux-system/cluster-vars.yaml
+++ b/clusters/home/flux-system/cluster-vars.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: flux-system
 data:
   GCP_PROJECT: dependable-yen-480702-b5
-  CLUSTER_DOMAIN: netl1.com
+  AWS_DOMAIN: netl1.com
+  CLOUDFLARE_DOMAIN: 9tzy.xyz
   GCP_REGION: australia-southeast1
   GCP_CERT_POOL_ID: home-ca-pool

--- a/infra/external-dns/helmrelease-aws.yaml
+++ b/infra/external-dns/helmrelease-aws.yaml
@@ -31,7 +31,7 @@ spec:
       - name: AWS_DEFAULT_REGION
         value: ap-southeast-2
     domainFilters:
-      - netl1.com
+      - ${AWS_DOMAIN}
     policy: upsert-only
     sources:
       - ingress

--- a/infra/external-dns/helmrelease-cloudflare.yaml
+++ b/infra/external-dns/helmrelease-cloudflare.yaml
@@ -24,7 +24,7 @@ spec:
             name: external-dns-cloudflare
             key: api-token
     domainFilters:
-      - 9tzy.xyz
+      - ${CLOUDFLARE_DOMAIN}
     policy: upsert-only
     sources:
       - ingress


### PR DESCRIPTION
Replace hardcoded domain names with ${AWS_DOMAIN} and ${CLOUDFLARE_DOMAIN} variables sourced from the cluster-vars ConfigMap. Rename the unused CLUSTER_DOMAIN variable accordingly.