### PR TITLE
add frontend workload

### DIFF
--- a/clusters/home/frontend.yaml
+++ b/clusters/home/frontend.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: frontend
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./infra/frontend
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: api-gateway
+    - name: namespaces

--- a/clusters/home/kustomization.yaml
+++ b/clusters/home/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
   - url-gen.yaml
   - url-read.yaml
   - api-gateway.yaml
+  - frontend.yaml
 
   # Ingress
   - traefik.yaml

--- a/infra/frontend/helmrelease.yaml
+++ b/infra/frontend/helmrelease.yaml
@@ -1,0 +1,23 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: frontend
+  namespace: frontend
+spec:
+  interval: 5m0s
+  releaseName: frontend
+  chart:
+    spec:
+      chart: frontend
+      version: "0.1.4"
+      sourceRef:
+        kind: HelmRepository
+        name: frontend
+        namespace: flux-system
+  values:
+    image:
+      repository: ghcr.io/andreistefanciprian/frontend
+      tag: latest
+    config:
+      LOG_LEVEL: DEBUG
+      BACKEND_HOST: api-gateway.api-gateway.svc

--- a/infra/frontend/helmrepository.yaml
+++ b/infra/frontend/helmrepository.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: frontend
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 5m
+  url: oci://ghcr.io/andreistefanciprian/urlshortener

--- a/infra/frontend/kustomization.yaml
+++ b/infra/frontend/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/infra/namespaces/frontend.yaml
+++ b/infra/namespaces/frontend.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: frontend

--- a/infra/namespaces/kustomization.yaml
+++ b/infra/namespaces/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - url-gen.yaml
   - url-read.yaml
   - api-gateway.yaml
+  - frontend.yaml


### PR DESCRIPTION
## Summary
- Add Flux CD manifests for the `frontend` service (OCI chart `ghcr.io/andreistefanciprian/urlshortener/frontend` v0.1.4)
- Configured with `BACKEND_HOST: api-gateway.api-gateway.svc`
- Kustomization depends on `api-gateway`

## Test plan
- [ ] `flux get kustomizations frontend`
- [ ] `flux get helmreleases -n frontend`
- [ ] `kubectl get pods -n frontend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)