### PR TITLE
fix helmrepository intervals for consistency

### DIFF
--- a/infra/api-gateway/helmrepository.yaml
+++ b/infra/api-gateway/helmrepository.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: flux-system
 spec:
   type: oci
-  interval: 5m
+  interval: 10m
   url: oci://ghcr.io/andreistefanciprian/urlshortener

--- a/infra/frontend/helmrepository.yaml
+++ b/infra/frontend/helmrepository.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: flux-system
 spec:
   type: oci
-  interval: 5m
+  interval: 10m
   url: oci://ghcr.io/andreistefanciprian/urlshortener

--- a/infra/url-gen/helmrepository.yaml
+++ b/infra/url-gen/helmrepository.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: flux-system
 spec:
   type: oci
-  interval: 5m
+  interval: 10m
   url: oci://ghcr.io/andreistefanciprian/urlshortener

--- a/infra/url-read/helmrepository.yaml
+++ b/infra/url-read/helmrepository.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: flux-system
 spec:
   type: oci
-  interval: 5m
+  interval: 10m
   url: oci://ghcr.io/andreistefanciprian/urlshortener


### PR DESCRIPTION
## Summary
- Align OCI HelmRepository `interval` from `5m` → `10m` for `url-gen`, `url-read`, `api-gateway`, and `frontend`
- Matches the interval used by all other HelmRepositories in the repo (bitnami, jetstack, external-dns, traefik, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)