### PR TITLE
add traefik-gateway: second Traefik instance for Gateway API

### DIFF
--- a/clusters/home/kustomization.yaml
+++ b/clusters/home/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
 
   # Ingress
   - traefik.yaml
+  - traefik-gateway.yaml
 
   # Security & Policy
   - priorityclasses.yaml

--- a/clusters/home/traefik-gateway.yaml
+++ b/clusters/home/traefik-gateway.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: traefik-gateway
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./infra/traefik-gateway
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: namespaces
+    - name: gateway-api-crds

--- a/infra/namespaces/kustomization.yaml
+++ b/infra/namespaces/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - redis.yaml
   - secrets-store-csi-driver.yaml
   - traefik.yaml
+  - traefik-gateway.yaml
   - url-gen.yaml
   - url-read.yaml
   - api-gateway.yaml

--- a/infra/namespaces/traefik-gateway.yaml
+++ b/infra/namespaces/traefik-gateway.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: traefik-gateway

--- a/infra/traefik-gateway/gatewayclass.yaml
+++ b/infra/traefik-gateway/gatewayclass.yaml
@@ -1,0 +1,6 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: traefik-gateway
+spec:
+  controllerName: traefik.io/gateway-controller

--- a/infra/traefik-gateway/helmrelease.yaml
+++ b/infra/traefik-gateway/helmrelease.yaml
@@ -1,0 +1,41 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: traefik-gateway
+  namespace: traefik-gateway
+spec:
+  interval: 5m0s
+  releaseName: traefik-gateway
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  chart:
+    spec:
+      chart: traefik
+      version: 34.3.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: flux-system
+  values:
+    # Private GKE internal LB — same as the Ingress Traefik instance
+    service:
+      annotations:
+        networking.gke.io/load-balancer-type: Internal
+        networking.gke.io/internal-load-balancer-allow-global-access: "true"
+    # Gateway API provider only — do not process Ingress or IngressRoute resources
+    providers:
+      kubernetesIngress:
+        enabled: false
+      kubernetesCRD:
+        enabled: false
+      kubernetesGateway:
+        enabled: true
+    # Disable IngressClass so it doesn't conflict with the existing traefik instance
+    ingressClass:
+      enabled: false
+      isDefaultClass: false

--- a/infra/traefik-gateway/kustomization.yaml
+++ b/infra/traefik-gateway/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - gatewayclass.yaml


### PR DESCRIPTION
## Summary

Adds a second Traefik instance dedicated to the [Gateway API](https://gateway-api.sigs.k8s.io/), running alongside the existing Ingress-based Traefik controller.

| | `traefik` (existing) | `traefik-gateway` (new) |
|---|---|---|
| Namespace | `traefik` | `traefik-gateway` |
| Provider | Ingress + CRD | Gateway API only |
| IngressClass | `traefik` | none |
| GatewayClass | — | `traefik-gateway` |
| Load balancer | GKE internal | GKE internal |

## Usage

Create a `Gateway` referencing the new class and attach `HTTPRoute`/`GRPCRoute` resources:

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: my-gateway
  namespace: my-namespace
spec:
  gatewayClassName: traefik-gateway
  listeners:
    - name: web
      port: 80
      protocol: HTTP
```

## Notes
- Reuses the existing `traefik` HelmRepository source (no new source needed)
- `gateway-api-crds` Kustomization must be ready before this deploys (`dependsOn` set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)