### PR TITLE
refine traefik-gateway: chart-managed GatewayClass, no default Gateway

### DIFF
--- a/infra/traefik-gateway/gatewayclass.yaml
+++ b/infra/traefik-gateway/gatewayclass.yaml
@@ -1,6 +1,0 @@
-apiVersion: gateway.networking.k8s.io/v1
-kind: GatewayClass
-metadata:
-  name: traefik-gateway
-spec:
-  controllerName: traefik.io/gateway-controller

--- a/infra/traefik-gateway/helmrelease.yaml
+++ b/infra/traefik-gateway/helmrelease.yaml
@@ -39,7 +39,10 @@ spec:
     ingressClass:
       enabled: false
       isDefaultClass: false
-    # Disable chart-managed GatewayClass — managed via gatewayclass.yaml instead
-    # to avoid duplicate resource creation
+    # GatewayClass managed by the chart
     gatewayClass:
+      enabled: true
+      name: private
+    # Disable the default Gateway — app-specific Gateways are managed separately
+    gateway:
       enabled: false

--- a/infra/traefik-gateway/kustomization.yaml
+++ b/infra/traefik-gateway/kustomization.yaml
@@ -2,4 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helmrelease.yaml
-  - gatewayclass.yaml


### PR DESCRIPTION
## Summary

Follow-up refinements to the `traefik-gateway` Helm release:

**GatewayClass — now chart-managed**
- Removed standalone `gatewayclass.yaml` to avoid duplicate resource creation
- Set `gatewayClass.enabled: true` + `name: private` in HelmRelease values
- The chart now owns the GatewayClass lifecycle (created on install, deleted on uninstall)
- Usage: `gatewayClassName: private` in app `Gateway` resources

**Default Gateway — disabled**
- Set `gateway.enabled: false` to suppress the chart's default `Gateway` resource
- App-specific `Gateway` resources will be deployed separately per application

🤖 Generated with [Claude Code](https://claude.com/claude-code)