### PR TITLE
fix traefik-gateway: bind entrypoints on ports 80/443 for Gateway API

### DIFF
--- a/infra/traefik-gateway/helmrelease.yaml
+++ b/infra/traefik-gateway/helmrelease.yaml
@@ -46,3 +46,27 @@ spec:
     # Disable the default Gateway — app-specific Gateways are managed separately
     gateway:
       enabled: false
+    # Entrypoints must bind on ports 80/443 to match Gateway listener ports.
+    # NET_BIND_SERVICE capability is required for non-root to bind to privileged ports.
+    ports:
+      web:
+        port: 80
+        exposedPort: 80
+        protocol: TCP
+      websecure:
+        port: 443
+        exposedPort: 443
+        protocol: TCP
+        # TLS is terminated at the Gateway level (cert-manager), not the entrypoint
+        tls:
+          enabled: false
+    securityContext:
+      capabilities:
+        add:
+          - NET_BIND_SERVICE
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true
+      runAsGroup: 65532
+      runAsNonRoot: true
+      runAsUser: 65532


### PR DESCRIPTION
## Summary
- Configures `web` and `websecure` entrypoints to bind on ports 80 and 443 directly
- Adds `NET_BIND_SERVICE` capability so the non-root Traefik process can bind to privileged ports
- Disables entrypoint-level TLS on `websecure` — TLS is terminated at the Gateway level by cert-manager

## Root Cause
Traefik's Gateway API provider matches listener ports against entrypoint ports. The default chart entrypoints use container ports `8000` (web) and `8443` (websecure), which don't match Gateway listeners requesting ports 80 and 443, resulting in `PortUnavailable` errors for all listeners.

## Test plan
- [ ] `flux reconcile kustomization traefik-gateway --with-source`
- [ ] `kubectl get pods -n traefik-gateway` — pod restarts cleanly
- [ ] `kubectl describe gateway urlshortener-gateway -n default` — all listeners show `Accepted: True`
- [ ] HTTP/HTTPS routes resolve for `9tzy.xyz` and `app.9tzy.xyz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)