### PR TITLE
fix cert-manager: enable Gateway API certificate provisioning

### DIFF
--- a/infra/cert-manager/core/helmrelease.yaml
+++ b/infra/cert-manager/core/helmrelease.yaml
@@ -29,3 +29,5 @@ spec:
     installCRDs: true
     # When this flag is enabled, secrets will be automatically removed when the certificate resource is deleted
     enableCertificateOwnerRef: true
+    # Enable automatic certificate provisioning from Gateway API resources
+    featureGates: "ExperimentalGatewayAPISupport=true"


### PR DESCRIPTION
## Summary
- Adds `featureGates: "ExperimentalGatewayAPISupport=true"` to the cert-manager HelmRelease

## Why
Without this feature gate, cert-manager ignores the `cert-manager.io/cluster-issuer` annotation on Gateway resources and never creates the referenced TLS certificate secrets, causing Traefik to report `Gateway Not Accepted` errors.

With this enabled, cert-manager automatically provisions certificates for any HTTPS Gateway listener whose parent Gateway has the annotation — no need for explicit Certificate resources.

## Test plan
- [ ] `flux reconcile kustomization cert-manager --with-source`
- [ ] `kubectl get certificate -n default` — `api-gateway-cert` and `frontend-cert` appear and become `Ready: True`
- [ ] `kubectl describe gateway urlshortener-gateway -n default` — all listeners show `Accepted: True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)