### PR TITLE
fix external-dns: change policy from upsert-only to sync

### DIFF
--- a/infra/external-dns/helmrelease-aws.yaml
+++ b/infra/external-dns/helmrelease-aws.yaml
@@ -39,6 +39,6 @@ spec:
         value: ap-southeast-2
     domainFilters:
       - ${AWS_DOMAIN}
-    policy: upsert-only
+    policy: sync
     sources:
       - ingress

--- a/infra/external-dns/helmrelease-cloudflare.yaml
+++ b/infra/external-dns/helmrelease-cloudflare.yaml
@@ -32,7 +32,7 @@ spec:
             key: api-token
     domainFilters:
       - ${CLOUDFLARE_DOMAIN}
-    policy: upsert-only
+    policy: sync
     sources:
       - ingress
       - gateway-httproute


### PR DESCRIPTION
## Summary
- Changes `policy: upsert-only` to `policy: sync` on both the Cloudflare and AWS external-dns instances

## Why
`upsert-only` only creates and updates DNS records — it never deletes them. With `sync`, external-dns will clean up stale records when the corresponding Ingress or HTTPRoute resources are deleted.

## Test plan
- [ ] `flux reconcile kustomization external-dns --with-source`
- [ ] Delete a test Ingress/HTTPRoute and verify the DNS record is removed from Cloudflare/Route53

🤖 Generated with [Claude Code](https://claude.com/claude-code)