### PR TITLE
fix cert-manager: enable Gateway API via config.enableGatewayAPI, bump to v1.19.4

### DIFF
--- a/infra/cert-manager/core/helmrelease.yaml
+++ b/infra/cert-manager/core/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cert-manager
-      version: 1.19.3
+      version: 1.19.4
       sourceRef:
         kind: HelmRepository
         name: jetstack-charts
@@ -30,4 +30,5 @@ spec:
     # When this flag is enabled, secrets will be automatically removed when the certificate resource is deleted
     enableCertificateOwnerRef: true
     # Enable automatic certificate provisioning from Gateway API resources
-    featureGates: "ExperimentalGatewayAPISupport=true"
+    config:
+      enableGatewayAPI: true


### PR DESCRIPTION
## Summary
- Replaces `featureGates: "ExperimentalGatewayAPISupport=true"` with `config.enableGatewayAPI: true`
- Bumps chart version from `1.19.3` to `1.19.4`

## Why
The `featureGates` string sets a CLI flag (`--feature-gates`) which is the old approach. For cert-manager v1.15+, Gateway API support is enabled via the `ControllerConfiguration` config object using `enableGatewayAPI: true`. Without this, the `gateway-shim` controller is skipped at startup even when the feature gate flag is present.

## Test plan
- [ ] `flux reconcile helmrelease cert-manager -n cert-manager`
- [ ] `kubectl logs -n cert-manager deploy/cert-manager | grep -i gateway` → shows `"starting controller" controller="gateway-shim"`
- [ ] `kubectl get certificate -n traefik-gateway` → certs provisioned automatically from Gateway annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)