### PR TITLE
debug: expose PUT /create and DELETE / on api-gateway HTTPRoute

### DIFF
--- a/infra/api-gateway/helmrelease.yaml
+++ b/infra/api-gateway/helmrelease.yaml
@@ -46,3 +46,12 @@ spec:
                 type: PathPrefix
                 value: /
               method: GET
+            # DEBUG ONLY - PUT /create and DELETE / should not be exposed to public
+            - path:
+                type: Exact
+                value: /create
+              method: PUT
+            - path:
+                type: PathPrefix
+                value: /
+              method: DELETE


### PR DESCRIPTION
For debug purposes only -- these methods should not be exposed to public.